### PR TITLE
added an ability to expand on finish for button

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ type button = {
   labelStyle?: Object,              // default = defaultLabelStyle
   maxWidth?: number,                // default = 240
   minWidth?: number,                // default = 40
+  shouldExpandOnFinish?: number,    // default = false
   noFill?: boolean,                 // default = false
   onError?: Function,               // default = () => null
   onLoad?: Function,                // default = () => null

--- a/button.js
+++ b/button.js
@@ -40,7 +40,7 @@ export default class Button extends Component {
     outputRange: [
       this.props.maxWidth || 240,
       this.props.minWidth || 40,
-      this.props.minWidth || 40
+      this.props.shouldExpandOnFinish ? (this.props.maxWidth || 240) : (this.props.minWidth || 40)
     ]
   });
 


### PR DESCRIPTION
Added a boolean property `shouldExpandOnFinish`. If it is set to true - on success/error the button will have the same width, as before the press.