### PR TITLE
fix inconsistent state occurring after button#error has been called once

### DIFF
--- a/button.js
+++ b/button.js
@@ -130,14 +130,14 @@ export default class extends Component {
   };
 
   reset = () =>
-    this.setState({ step: 0 }, () =>
+    this.setState({ step: 0, error: false }, () =>
       Animated.spring(this.animated, { toValue: 0 }).start(
         ({ finished }) => finished && this.props.onReset && this.props.onReset()
       )
     );
 
   load = () =>
-    this.setState({ step: 1 }, () =>
+    this.setState({ step: 1, error: false }, () =>
       Animated.spring(this.animated, { toValue: 1 }).start(
         ({ finished }) => finished && this.props.onLoad && this.props.onLoad()
       )

--- a/button.js
+++ b/button.js
@@ -100,7 +100,7 @@ export default class extends Component {
   };
 
   success = () => {
-    this.setState({ step: 2 }, () =>
+    this.setState({ step: 2, error: false }, () =>
       Animated.spring(this.animated, { toValue: 2 }).start(
         ({ finished }) =>
           finished && this.props.onSuccess && this.props.onSuccess()


### PR DESCRIPTION
hello,
i noticed that the button would still show the error icon in case of success if an error had occurred on a previous click. this was due to a forgotten `this.setState({ error: false, ... })` in the success function. 
this is my first pull request, i hope i did everything right. 
thanks for your work!
nicolai